### PR TITLE
feat: Add GitHub bug report template with YAML syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,66 @@
+name: "\U0001F41B Bug Report"
+description: Report a reproducible bug or regression in Joplin.
+title: ''
+labels: ['bug']
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <!--
+          Please provide a clear and concise description of what the bug is. (In the section Steps To Reproduce.)
+          Include screenshots for UI problems if needed.
+          DO NOT create screenshots of text !!! Copy and paste the text into a code block.
+          Please test using the latest Joplin release to make sure your issue has not already been fixed.
+        -->
+
+        <!--
+          IMPORTANT: If you are reporting a clipper bug, please include an example URL that shows the issue.
+          Without the URL the issue is likely to be closed.
+        -->
+
+  - type: input
+    id: joplin_version
+    attributes:
+      label: Joplin version
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+    validations:
+      required: true
+
+  - type: input
+    id: os_specifics
+    attributes:
+      label: OS specifics
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. 
+        2. 
+        3. 
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Describe what you expected to happen
+
+  - type: textarea
+    id: logfile
+    attributes:
+      label: Logfile
+      description: |
+        <!--
+          Please attach a debug log. Issues without a debug log are likely to stall.
+          For information on how to collect a log file: https://joplinapp.org/debugging/
+        -->


### PR DESCRIPTION
copilot:walkthrough

This commit adds a new GitHub bug report template using the YAML syntax, based on the existing Markdown template

With this new template, users can now create detailed and structured bug reports for Joplin, improving issue tracking and resolution.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
